### PR TITLE
fix: use new MatrikkelenAdresse endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ Norway:
 * [Lantmäteriet product page https://geotorget.lantmateriet.se/dokumentation/GEODOK/15/latest.html]
 * [Norway OSM import plan https://wiki.openstreetmap.org/wiki/Import/Catalogue/Address_import_for_Norway]
 * [Kartverket SOSI municipality codes](https://register.geonorge.no/sosi-kodelister/kommunenummer)
-* [Kartverket street address files](https://nedlasting.geonorge.no/geonorge/Basisdata/MatrikkelenVegadresse/CSV/)
+* [Kartverket street address files](https://nedlasting.geonorge.no/geonorge/Basisdata/MatrikkelenAdresse/CSV/)
 * [Overpass API](http://overpass-api.de)
 * [addr2osm/corrections.json](https://github.com/NKAmapper/addr2osm/blob/master/corrections.json) - Street name corrections, based on [Github addrnodeimport street name corrections](https://github.com/rubund/addrnodeimport/blob/master/xml/corrections.xml)

--- a/addr2osm.py
+++ b/addr2osm.py
@@ -22,7 +22,7 @@ from itertools import tee
 from xml.etree import ElementTree as ET
 
 
-version = "2.1.0"
+version = "2.1.1"
 
 debug = False
 
@@ -425,15 +425,15 @@ def process_municipality (municipality_id):
 
 	# Load latest address file for municipality from Kartverket
 
-	filename = "Basisdata_%s_%s_4258_MatrikkelenVegadresse_CSV" % (municipality_id, municipality[ municipality_id ])
+	filename = "Basisdata_%s_%s_4258_MatrikkelenAdresse_CSV" % (municipality_id, municipality[ municipality_id ])
 	filename = filename.replace("Æ","E").replace("Ø","O").replace("Å","A").replace("æ","e").replace("ø","o").replace("å","a")
 	filename = filename.replace(" ", "_")
 
 	message ("\nLoading address file '%s' from Kartverket\n" % filename)
 
-	file_in = open_url("https://nedlasting.geonorge.no/geonorge/Basisdata/MatrikkelenVegadresse/CSV/" + filename + ".zip")
+	file_in = open_url("https://nedlasting.geonorge.no/geonorge/Basisdata/MatrikkelenAdresse/CSV/" + filename + ".zip")
 	zip_file = zipfile.ZipFile(BytesIO(file_in.read()))
-	csv_file = zip_file.open(filename + "/matrikkelenVegadresse.csv")
+	csv_file = zip_file.open(filename + "/matrikkelenAdresse.csv")
 	addr_table1, addr_table2 = tee(csv.DictReader(TextIOWrapper(csv_file, "utf-8"), delimiter=";"), 2)
 
 	# Initiate loop


### PR DESCRIPTION
[https://Kartkatalog - Matrikkelen - Vegadresse](https://kartkatalog.geonorge.no/metadata/matrikkelen-vegadresse/e628729b-90fc-4f32-b018-655e045c541d) har publisert et varsel: [Avviklet datasett](https://register.geonorge.no/varsler/matrikkelen-vegadresse/b1d09aeb-30f5-4ded-a814-26b12ee2008a).

Ser ut som å bytte rent 1:1 fungerer fint. Eneste virker ut som Oslo har et par addresser ekstra

Gammelt endepunkt:
<img width="779" height="767" alt="Screenshot 2026-01-14 at 20 02 17" src="https://github.com/user-attachments/assets/1c1e76d0-5aa6-442b-b4b3-54cb5aa8b075" />

Nytt endepunkt:
<img width="791" height="785" alt="Screenshot 2026-01-14 at 20 05 32" src="https://github.com/user-attachments/assets/f3ad752d-62ca-4b82-be10-237a7807a8b2" />
